### PR TITLE
Fix: syncAgents() fails in cron context when connection is in non-root entity

### DIFF
--- a/src/WazuhAgent.php
+++ b/src/WazuhAgent.php
@@ -583,8 +583,7 @@ class WazuhAgent extends CommonDBTM {
     }
 
     static function syncAgents(): bool {
-        $entities = array_values(getSonsOf(Entity::getTable(), Session::getActiveEntity()));
-        $ids = (new Connection())->find(['is_deleted' => 0, 'is_conn_active' => 1, Entity::getForeignKeyField() => $entities]);
+        $ids = (new Connection())->find(['is_deleted' => 0, 'is_conn_active' => 1]);
         $allOk = true;
         foreach ($ids as $id) {
             PluginLogger::debug("Syncing agents: " . PluginLogger::implodeWithKeys($id));


### PR DESCRIPTION
### Testing

To reproduce:
1. Install plugin and configure the Wazuh connection in any non-root entity (entities_id != 0)
2. Trigger sync via cron or GLPI automatic actions
3. Observe that no agents are created despite a successful API/indexer connection

To verify the fix:
1. Apply the one-line change to syncAgents()
2. Also update the connection record's entities_id to match your target entity if it was left as 0
3. Trigger sync — agents should now appear with correct entities_id and is_deleted: 0

### Root Cause
Session::getActiveEntity() returns 0 in any context without an active user session (cron, CLI). If the connection lives in entity 1+, the find() call returns nothing and sync silently does nothing.